### PR TITLE
Spring Security Bugfixes

### DIFF
--- a/src/main/java/com/savicsoft/carpooling/exception/DuplicateResourceException.java
+++ b/src/main/java/com/savicsoft/carpooling/exception/DuplicateResourceException.java
@@ -1,0 +1,21 @@
+package com.savicsoft.carpooling.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.Date;
+
+@ResponseStatus(code = HttpStatus.CONFLICT)
+@Getter
+public class DuplicateResourceException extends RuntimeException {
+    private final Date timestamp;
+    private final int status;
+    public DuplicateResourceException(String message) {
+        super(message);
+        this.timestamp = new Date();
+        this.status = 409;
+        setStackTrace(new StackTraceElement[0]);
+    }
+}
+

--- a/src/main/java/com/savicsoft/carpooling/exception/ValidationException.java
+++ b/src/main/java/com/savicsoft/carpooling/exception/ValidationException.java
@@ -1,0 +1,48 @@
+package com.savicsoft.carpooling.exception;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@ControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class ValidationException extends ResponseEntityExceptionHandler {
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+        Map<String, Object> responseBody = new LinkedHashMap<>();
+        responseBody.put("timestamp", new Date());
+        responseBody.put("status", status.value());
+
+        List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+
+        List<Map<String, String>> invalidFields = fieldErrors.stream()
+                .map(fieldError -> {
+                    Map<String, String> fieldErrorMap = new LinkedHashMap<>();
+                    fieldErrorMap.put("field", fieldError.getField());
+                    if (Objects.requireNonNull(fieldError.getDefaultMessage()).contains("Failed to convert value")){
+                        fieldErrorMap.put("error", "Type Mismatch Error. Make sure to use the correct data types");
+                    }
+                    fieldErrorMap.put("error", fieldError.getDefaultMessage());
+                    return fieldErrorMap;
+                })
+                .collect(Collectors.toList());
+
+        responseBody.put("invalidFields", invalidFields);
+
+        return new ResponseEntity<>(responseBody, headers, status);
+    }
+}

--- a/src/main/java/com/savicsoft/carpooling/exception/errorinfo/ErrorInfo.java
+++ b/src/main/java/com/savicsoft/carpooling/exception/errorinfo/ErrorInfo.java
@@ -2,9 +2,11 @@ package com.savicsoft.carpooling.exception.errorinfo;
 
 import lombok.Data;
 
+import java.util.Date;
+
 @Data
 public class ErrorInfo {
     private String message;
     private int statusCode;
-    private long timestamp;
+    private Date timestamp;
 }

--- a/src/main/java/com/savicsoft/carpooling/exception/handlers/GlobalExceptionHandler.java
+++ b/src/main/java/com/savicsoft/carpooling/exception/handlers/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.savicsoft.carpooling.exception.*;
 import com.savicsoft.carpooling.exception.errorinfo.ErrorInfo;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -25,7 +26,7 @@ public class GlobalExceptionHandler {
         ErrorInfo errorInfo = new ErrorInfo();
         errorInfo.setMessage(e.getMessage());
         errorInfo.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR.value());
-        errorInfo.setTimestamp(new Date().getTime());
+        errorInfo.setTimestamp(new Date());
 
         return new ResponseEntity<>(errorInfo, HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -36,7 +37,7 @@ public class GlobalExceptionHandler {
         ErrorInfo errorInfo = new ErrorInfo();
         errorInfo.setMessage(e.getMessage());
         errorInfo.setStatusCode(HttpStatus.NOT_FOUND.value());
-        errorInfo.setTimestamp(new Date().getTime());
+        errorInfo.setTimestamp(new Date());
 
         return new ResponseEntity<>(errorInfo, HttpStatus.NOT_FOUND);
     }
@@ -47,7 +48,7 @@ public class GlobalExceptionHandler {
             ErrorInfo errorInfo = new ErrorInfo();
             errorInfo.setMessage(e.getMessage());
             errorInfo.setStatusCode(HttpStatus.BAD_REQUEST.value());
-            errorInfo.setTimestamp(new Date().getTime());
+            errorInfo.setTimestamp(new Date());
 
             return new ResponseEntity<>(errorInfo, HttpStatus.BAD_REQUEST);
     }
@@ -58,7 +59,7 @@ public class GlobalExceptionHandler {
         ErrorInfo errorInfo = new ErrorInfo();
         errorInfo.setMessage(e.getMessage());
         errorInfo.setStatusCode(HttpStatus.FORBIDDEN.value());
-        errorInfo.setTimestamp(new Date().getTime());
+        errorInfo.setTimestamp(new Date());
 
         return new ResponseEntity<>(errorInfo, HttpStatus.FORBIDDEN);
     }
@@ -69,8 +70,27 @@ public class GlobalExceptionHandler {
         ErrorInfo errorInfo = new ErrorInfo();
         errorInfo.setMessage(e.getMessage());
         errorInfo.setStatusCode(HttpStatus.UNAUTHORIZED.value());
-        errorInfo.setTimestamp(new Date().getTime());
+        errorInfo.setTimestamp(new Date());
 
+        return new ResponseEntity<>(errorInfo, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(DuplicateResourceException.class)
+    public ResponseEntity<ErrorInfo> handleDuplicateUserException(DuplicateResourceException e) {
+
+        ErrorInfo errorInfo = new ErrorInfo();
+        errorInfo.setMessage(e.getMessage());
+        errorInfo.setStatusCode(HttpStatus.CONFLICT.value());
+        errorInfo.setTimestamp(new Date());
+
+        return new ResponseEntity<>(errorInfo, HttpStatus.CONFLICT);
+    }
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ErrorInfo> handleBadCredentialsException(BadCredentialsException e){
+        ErrorInfo errorInfo = new ErrorInfo();
+        errorInfo.setMessage(e.getMessage());
+        errorInfo.setStatusCode(HttpStatus.UNAUTHORIZED.value());
+        errorInfo.setTimestamp(new Date());
         return new ResponseEntity<>(errorInfo, HttpStatus.UNAUTHORIZED);
     }
 }

--- a/src/main/java/com/savicsoft/carpooling/security/auth/AuthController.java
+++ b/src/main/java/com/savicsoft/carpooling/security/auth/AuthController.java
@@ -1,5 +1,6 @@
 package com.savicsoft.carpooling.security.auth;
 
+import com.savicsoft.carpooling.exception.DuplicateResourceException;
 import com.savicsoft.carpooling.security.payload.JwtResponse;
 import com.savicsoft.carpooling.security.payload.LoginRequest;
 import com.savicsoft.carpooling.security.payload.MessageResponse;
@@ -85,15 +86,15 @@ public class AuthController {
 
         UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
 
-        return ResponseEntity
-                .ok(new JwtResponse(jwt, userDetails.getId(), userDetails.getUsername(), userDetails.getEmail()));
+        return ResponseEntity.ok(
+                new JwtResponse(jwt, userDetails.getId(), userDetails.getUsername(), userDetails.getEmail()));
     }
 
     @PostMapping("/signup")
     public ResponseEntity<?> registerUser(@Valid @RequestBody SignupRequest signUpRequest) throws MessagingException, UnsupportedEncodingException {
 
         if (userRepository.existsByEmail(signUpRequest.getEmail())) {
-            return ResponseEntity.badRequest().body(new MessageResponse("Error: Email is already in use!"));
+            throw new DuplicateResourceException("Email Already in use");
         }
         // Create default preferences for the user
 

--- a/src/main/java/com/savicsoft/carpooling/security/auth/AuthEntryPointJwt.java
+++ b/src/main/java/com/savicsoft/carpooling/security/auth/AuthEntryPointJwt.java
@@ -1,17 +1,15 @@
 package com.savicsoft.carpooling.security.auth;
 
 
-import java.io.IOException;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
-import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
 
 
 @Component
@@ -20,10 +18,12 @@ public class AuthEntryPointJwt implements AuthenticationEntryPoint {
     private static final Logger logger = LoggerFactory.getLogger(AuthEntryPointJwt.class);
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
-            throws IOException, ServletException {
-        logger.error("Unauthorized error: {}", authException.getMessage());
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Error: Unauthorized");
-    }
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
 
+        logger.error("Unauthorized error: {}", authException.getMessage());
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+                authException.getMessage());
+    }
 }

--- a/src/main/java/com/savicsoft/carpooling/security/auth/AuthTokenFilter.java
+++ b/src/main/java/com/savicsoft/carpooling/security/auth/AuthTokenFilter.java
@@ -1,39 +1,40 @@
 package com.savicsoft.carpooling.security.auth;
-import java.io.IOException;
 
+import com.savicsoft.carpooling.security.services.UserDetailsServiceImpl;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import com.savicsoft.carpooling.security.services.UserDetailsServiceImpl;
+import java.io.IOException;
 
-
+@Component
 @FieldDefaults(level= AccessLevel.PRIVATE)
+@RequiredArgsConstructor
 public class AuthTokenFilter extends OncePerRequestFilter {
-     @Autowired
-     JwtUtils jwtUtils;
-     @Autowired
-     UserDetailsServiceImpl userDetailsService;
+     final JwtUtils jwtUtils;
+     final UserDetailsServiceImpl userDetailsService;
 
     private static final Logger logger = LoggerFactory.getLogger(AuthTokenFilter.class);
-    // todo add spring validator
+
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain)
             throws ServletException, IOException {
         try {
             String jwt = parseJwt(request);

--- a/src/main/java/com/savicsoft/carpooling/security/auth/oauth/OauthController.java
+++ b/src/main/java/com/savicsoft/carpooling/security/auth/oauth/OauthController.java
@@ -1,0 +1,22 @@
+package com.savicsoft.carpooling.security.auth.oauth;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/oauth/login")
+public class OauthController {
+    @GetMapping("/google")
+    public String OauthGoogleLogin() {
+        // Redirect to Google OAuth2 login page for now
+        return "redirect:/oauth2/authorization/google";
+    }
+
+    @GetMapping("/facebook")
+    public String OauthFacebookLogin() {
+        // Redirect to Facebook OAuth2 login page for now
+        return "redirect:/oauth2/authorization/facebook";
+    }
+
+}

--- a/src/main/java/com/savicsoft/carpooling/security/config/AuthenticationConfig.java
+++ b/src/main/java/com/savicsoft/carpooling/security/config/AuthenticationConfig.java
@@ -1,0 +1,34 @@
+package com.savicsoft.carpooling.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AuthenticationConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder () {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager (AuthenticationConfiguration authConfig) throws Exception {
+        return authConfig.getAuthenticationManager();
+    }
+
+    @Bean
+    public DaoAuthenticationProvider authenticationProvider(UserDetailsService userDetailsService,
+                                                            PasswordEncoder passwordEncoder) {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder);
+
+        return authProvider;
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -56,3 +56,4 @@ spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.transport.protocol=smtp
 spring.mail.from.email=testmvp@gmail.com
+spring.mail.protocol=smtp


### PR DESCRIPTION
(1) Threw appropriate exception for registering existing User.
(2) Refractor some jwt implementation code.
(3) Fix exception handling for the case of bad credentials. 
4) Added DuplicateResourceException class for duplicate entries attempts. 
(5) Changed the type of timestamp to Date from long in GlobalExceptionHandler because long only produced the date in ms and modified the exceptions in GlobalExceptionHandler accordingly. 
(6) Removed spring security's default login because it is not needed and set the session to stateless. Also disabled oauth2 for now until it is properly implemented. p.s it is still there just disabled. 
(7) Added ValidationException class. this class is for exceptions caused by user violating validations on dto fields and displaying them in a more structured way.